### PR TITLE
fix: Avoid deadloop when the waker process gets killed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{erl, src, hrl}]
+indent_style = space
+indent_size = 4
+
+[Makefile]
+indent_style = tab

--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -1,0 +1,31 @@
+name: Run test case
+
+on: [push, pull_request]
+
+jobs:
+
+    run_test_case:
+        runs-on: ubuntu-latest
+
+        strategy:
+          matrix:
+            os:
+              - ubuntu20.04
+            otp:
+              - 25.1.2-2
+            elixir:
+              - 1.13.4
+            arch:
+              - amd64
+        container: ghcr.io/emqx/emqx-builder/5.0-26:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
+
+        steps:
+        - uses: actions/checkout@v1
+
+        - name: Compile
+          run: |
+            make
+
+        - name: Concuerror tests
+          run : |
+            make concuerror_test

--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -17,7 +17,7 @@ jobs:
               - 1.13.4
             arch:
               - amd64
-        container: ghcr.io/emqx/emqx-builder/5.0-26:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
+        container: ghcr.io/emqx/emqx-builder/5.0-29:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
 
         steps:
         - uses: actions/checkout@v1

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ dialyzer:
 CONCUERROR := $(BUILD_DIR)/Concuerror/bin/concuerror
 CONCUERROR_RUN := $(CONCUERROR) \
 	--treat_as_normal shutdown --treat_as_normal normal --treat_as_normal intentional \
-	--treat_as_normal optvar_set --treat_as_normal optvar_stopped --treat_as_normal optvar_retry \
+	--treat_as_normal optvar_set --treat_as_normal optvar_stopped --treat_as_normal optvar_retry --treat_as_normal killed \
 	-x code -x code_server -x error_handler \
 	-pa $(BUILD_DIR)/concuerror+test/lib/optvar/ebin
 
@@ -68,6 +68,8 @@ concuerror_test: $(CONCUERROR)
 	$(call concuerror,optvar_wait_multiple_timeout_test)
 	$(call concuerror,optvar_list_test)
 	$(call concuerror,optvar_set_unset_test)
+	$(call concuerror,optvar_set_unset_race_test)
+	$(call concuerror,optvar_zombie_test)
 
 $(CONCUERROR):
 	mkdir -p _build/

--- a/src/optvar_app.erl
+++ b/src/optvar_app.erl
@@ -10,11 +10,10 @@
 -export([start/2, stop/1]).
 
 start(_StartType, _StartArgs) ->
-  optvar:init(),
-  optvar_sup:start_link().
+    optvar_sup:start_link().
 
 stop(_State) ->
-  optvar:stop(),
-  ok.
+    optvar:stop(),
+    ok.
 
 %% internal functions

--- a/src/optvar_sup.erl
+++ b/src/optvar_sup.erl
@@ -30,6 +30,7 @@ init([]) ->
                  intensity => 0,
                  period => 1},
     ChildSpecs = [],
+    optvar:init(),
     {ok, {SupFlags, ChildSpecs}}.
 
 %% internal functions


### PR DESCRIPTION
Optvar operates under an assumption that waker processes never get killed by the third party.
However, when it does happen by accident, there is a risk of deadloop. This PR makes sure that it doesn't happen.